### PR TITLE
fix: Move ethers from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.11",
     "chai": "^5.1.1",
-    "ethers": "^6.12.1",
     "jest": "^29.7.0",
     "prettier": "3.2.5",
     "ts-jest": "^29.1.2",
@@ -39,6 +38,7 @@
   "dependencies": {
     "@types/websocket": "^1.0.10",
     "dotenv": "^16.4.5",
+    "ethers": "^6.12.1",
     "starknet": "==6.17.0",
     "websocket": "^1.0.35"
   },


### PR DESCRIPTION
**Problem:**
The `ethers` package is incorrectly listed in `devDependencies`. However, it's required for the runtime operation of `layerakira-js`.

**Impact:**
This forces users to manually install `ethers` in their projects when using `layerakira-js`, leading to extra setup steps and potential dependency issues.

**Solution:**
This PR moves `ethers` from `devDependencies` to `dependencies`.

**Benefit:**
`ethers` will now be automatically installed alongside `layerakira-js`, ensuring the package works correctly out-of-the-box and simplifying the developer experience.